### PR TITLE
filename should contain the whole route from root

### DIFF
--- a/index.js
+++ b/index.js
@@ -325,7 +325,7 @@ function readdirAsync(dir, container, _this, callback) {
             process();
           });
         } else {
-          var fileName = currentPath.substring(currentPath.lastIndexOf('/') + 1, currentPath.length);
+          var fileName = path.relative(subPath, currentPath);
           var props = {container: container, name: fileName, location: subPath };
           populateMetadata(stat, props);
           var outFile = new File(_this, props);


### PR DESCRIPTION
Right now if I have a following directory structure the with following configuration:

```
./
  ./data
     ./foo
        ./bar.json
```

```
var client = pkgcloud.storage.createClient({
  provider: 'filesystem',
  root: './'
});

client.getFiles('data', function(err, files) {
  files[0].name === 'bar.json';
});
```

As you can see the filename will only contain the basename of the file, which is wrong (or at least not compatible with other services, like S3, where the whole route from container to the file will be incuded in the filename. 

So it should be the relative position from container, `foo/bar.json`.

This is much like a proposal, if you think this should be the proper way, I'm gonna add test as well.
